### PR TITLE
新增: 威海日报

### DIFF
--- a/list.csv
+++ b/list.csv
@@ -6755,3 +6755,4 @@ IPO捕手,Mzg3MTQ3Nzc0Ng==,""
 中利财经,MjM5OTE5MjkxNQ==,""
 工信头条,MjM5NjU5MzYwMA==,""
 海通霞光道,MzU0NDkxMjg3OA==,""
+


### PR DESCRIPTION
《威海日报》是中共威海市委机关报，是您了解威海经济社会的第一选择。威海日报公众号每日推送威海重要政经新闻、权威资讯。只需一键关注，便可知晓威海大事。